### PR TITLE
Fix load authserver.conf from /etc/ folder

### DIFF
--- a/src/server/authserver/CMakeLists.txt
+++ b/src/server/authserver/CMakeLists.txt
@@ -74,7 +74,7 @@ add_executable(authserver
 add_dependencies(authserver revision.h)
 
 if( NOT WIN32 )
-  add_definitions(-D_TRINITY_REALM_CONFIG='"${CONF_DIR}/authserver.conf"')
+  add_definitions(-D_AUTHSERVER_CONFIG='"${CONF_DIR}/authserver.conf"')
 endif()
 
 if( UNIX )


### PR DESCRIPTION
*NOT "_TRINITY_REALM_CONFIG", for skyfire is "_AUTHSERVER_CONFIG"!
check  src/server/authserver/Main.cpp

now correct load authserver.conf from /etc/ folder
